### PR TITLE
feat(ci): Optimise and check minimal-crates versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
       - name: cargo check
         run: |
           rm -f Cargo.lock
-          cargo +nightly check -Z minimal-versions --workspace --all-features --libs --bins
+          cargo +nightly check -Z minimal-versions --workspace --all-features --lib --bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         run: cargo test --release --locked --workspace --all-features --bins --tests --examples
 
   minimal-crates:
+    runs-on: ${{ matrix.target.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         run: cargo test --locked --workspace --all-features --bins --tests --examples
 
   test-release:
+    runs-on: ${{ matrix.target.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: swatinem/rust-cache@v2
       - name: cargo check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,123 @@
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      # This helps fill the caches properly, caches are not shared between PRs.
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  MSRV: "1.63"
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -Dwarnings
 
 jobs:
-  cargo_tests:
-    name: ${{ matrix.target.name }} ${{ matrix.channel }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swtinem/rust-cache@v2
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --locked --workspace --all-targets --all-features
+
+  test:
     runs-on: ${{ matrix.target.os }}
     strategy:
       fail-fast: false
       matrix:
-        target: [
-          { "os": "ubuntu-latest",  "toolchain": "x86_64-unknown-linux-gnu", "name": "Linux GNU" },
-          { "os": "macOS-latest",   "toolchain": "x86_64-apple-darwin",      "name": "macOS" },
-          { "os": "windows-latest", "toolchain": "x86_64-pc-windows-msvc",   "name": "Windows MSVC" },
-          { "os": "windows-latest", "toolchain": "x86_64-pc-windows-gnu",    "name": "Windows GNU" }
-        ]
-        channel: [stable, beta, nightly]
-
+        target:
+          - os: "ubuntu-latest"
+            toolchain: "x86_64-unknown-linux-gnu"
+            name: "Linux GNU"
+          - os: "macOS-latest"
+            toolchain: "x86_64-apple-darwin"
+            name: "macOS"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-msvc"
+            name: "Windows MSVC"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-gnu"
+            name: "Windows GNU"
+        channel:
+          - "stable"
+          - "beta"
+          - "nightly"
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ format('{0}-{1}', matrix.channel, matrix.target.toolchain) }}
-        profile: minimal
-        override: true
-    - name: test lib
-      run: cargo test
-    - name: test lib with --release
-      run: cargo test --release
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.channel }}
+          targets: ${{ matrix.target.toolchain }}
+      - uses: swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test --locked --workspace --all-features --bins --tests --examples
+
+  test-release:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: "ubuntu-latest"
+            toolchain: "x86_64-unknown-linux-gnu"
+            name: "Linux GNU"
+          - os: "macOS-latest"
+            toolchain: "x86_64-apple-darwin"
+            name: "macOS"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-msvc"
+            name: "Windows MSVC"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-gnu"
+            name: "Windows GNU"
+        channel:
+          - "stable"
+          - "beta"
+          - "nightly"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.channel }}
+          targets: ${{ matrix.target.toolchain }}
+      - uses: swatinem/rust-cache@v2
+      - name: cargo test
+        run: cargo test --release --locked --workspace --all-features --bins --tests --examples
+
+  minimal-crates:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: "ubuntu-latest"
+            toolchain: "x86_64-unknown-linux-gnu"
+            name: "Linux GNU"
+          - os: "macOS-latest"
+            toolchain: "x86_64-apple-darwin"
+            name: "macOS"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-msvc"
+            name: "Windows MSVC"
+          - os: "windows-latest"
+            toolchain: "x86_64-pc-windows-gnu"
+            name: "Windows GNU"
+        channel:
+          - "stable"
+          - "beta"
+          - "nightly"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.channel }}
+          targets: ${{ matrix.target.toolchain }}
+      - uses: swatinem/rust-cache@v2
+      - name: cargo check
+        run: |
+          rm -f Cargo.lock
+          cargo +nightly check -Z minimal-versions --workspace --all-features --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,16 @@ jobs:
       - name: cargo test
         run: cargo test --release --locked --workspace --all-features --bins --tests --examples
 
+  # Checks correct runtime deps and features are requested by not including dev-dependencies.
+  check-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --workspace --all-features --lib --bins
+
   minimal-crates:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,33 +91,10 @@ jobs:
         run: cargo test --release --locked --workspace --all-features --bins --tests --examples
 
   minimal-crates:
-    runs-on: ${{ matrix.target.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - os: "ubuntu-latest"
-            toolchain: "x86_64-unknown-linux-gnu"
-            name: "Linux GNU"
-          - os: "macOS-latest"
-            toolchain: "x86_64-apple-darwin"
-            name: "macOS"
-          - os: "windows-latest"
-            toolchain: "x86_64-pc-windows-msvc"
-            name: "Windows MSVC"
-          - os: "windows-latest"
-            toolchain: "x86_64-pc-windows-gnu"
-            name: "Windows GNU"
-        channel:
-          - "stable"
-          - "beta"
-          - "nightly"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.channel }}
-          targets: ${{ matrix.target.toolchain }}
+      - uses: dtolnay/rust-toolchain@stable
       - uses: swatinem/rust-cache@v2
       - name: cargo check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
       - name: cargo check
         run: |
           rm -f Cargo.lock
-          cargo +nightly check -Z minimal-versions --workspace --all-features --all-targets
+          cargo +nightly check -Z minimal-versions --workspace --all-features --libs --bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: swtinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ smallvec = "1"
 
 ouroboros = { version = "0.15", optional = true }
 bytes = { version = "1" }
-tokio = { version = "1", features = ["full"], optional = true }
+tokio = { version = "1", features = ["io-util"], optional = true }
 futures = { version = "0.3", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["data-structures"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake3 = "1.3.3"
+blake3 = "1"
 range-collections = "0.4.0"
 smallvec = "1"
 
-ouroboros = { version = "0.15.6", optional = true }
-bytes = { version = "1.4.0" }
-tokio = { version = "1.24.1", features = ["full"], optional = true }
-futures = { version = "0.3.27", optional = true }
+ouroboros = { version = "0.15", optional = true }
+bytes = { version = "1" }
+tokio = { version = "1", features = ["full"], optional = true }
+futures = { version = "0.3", optional = true }
 
 [features]
 tokio_io = ["tokio", "futures", "ouroboros"]
@@ -28,7 +28,7 @@ default = ["tokio_io"]
 [dev-dependencies]
 hex = "0.4.3"
 bao = "0.12.1"
-tokio = { version = "1.24.1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 # abao with chunk group size 16 (abao default)
 abao = { git = "https://github.com/n0-computer/abao", branch = "post-order-outboard", features = ["group_size_1k"], default_features = false }
 proptest = "1.0.0"

--- a/src/io/tokio.rs
+++ b/src/io/tokio.rs
@@ -173,6 +173,8 @@ impl<'a, R: AsyncRead + Unpin> DecodeResponseStreamRef<'a, R> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<DecodeResponseItem, DecodeError>>> {
+        // TODO: fix this clippy lint
+        #[allow(clippy::never_loop)]
         Poll::Ready(Some(loop {
             // fill the buffer if needed
             ready!(self.poll_fill_buffer(cx))?;
@@ -423,6 +425,8 @@ impl<'a, R: AsyncRead + Unpin> AsyncResponseDecoderRef<'a, R> {
         }
     }
 
+    // TODO: fix this clippy lint
+    #[allow(clippy::unused_io_amount)]
     pub async fn read_tree(&mut self) -> io::Result<&BaoTree> {
         self.read(&mut []).await?;
         Ok(self.tree().unwrap())
@@ -562,6 +566,8 @@ impl<R: AsyncRead + Unpin, Q: AsRef<RangeSetRef<ChunkNum>> + 'static> AsyncRespo
     /// Read the tree geometry from the encoded stream.
     ///
     /// This is useful for determining the size of the decoded stream.
+    // TODO: fix this clippy lint
+    #[allow(clippy::unused_io_amount)]
     pub async fn read_tree(&mut self) -> io::Result<BaoTree> {
         self.read(&mut []).await?;
         Ok(self.0.with_inner(|x| *x.as_ref().unwrap().tree().unwrap()))


### PR DESCRIPTION
- Optimises the CI tasks that run lint and tests to do less recompiling.
- Add clippy run, some lints still need fixing but let's start somewhere.
- Add check for minimal crate versions of dependencies.
- Loosen the requirements on dependencies, this is a lib and it forces 
  too high selections on users.
- Don't depend on all tokio features.