### PR TITLE
have separate outboard traits for sync and async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.4.1"
+version = "0.5.0-beta1"
 dependencies = [
  "abao",
  "bao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bao-tree"
-version = "0.4.1"
+version = "0.5.0-beta1"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 description = "BLAKE3 verfiied streaming with custom chunk groups and range set queries"
 license = "MIT OR Apache-2.0"

--- a/src/outboard.rs
+++ b/src/outboard.rs
@@ -1,120 +1,14 @@
-//! The [Outboard] trait and implementations
-use blake3::guts::parent_cv;
+//! Implementations of the outboard traits
 use range_collections::RangeSet2;
 
 use super::{outboard_size, TreeNode};
-use crate::{BaoTree, BlockSize, ByteNum, ChunkNum};
+use crate::{io::sync::Outboard, BaoTree, BlockSize, ByteNum};
 use std::io::{self, Read};
 
 macro_rules! io_error {
     ($($arg:tt)*) => {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, format!($($arg)*)))
     };
-}
-
-/// An outboard is a just a thing that knows how big it is and can get you the hashes for a node.
-pub trait Outboard {
-    /// The root hash
-    fn root(&self) -> blake3::Hash;
-    /// The tree. This contains the information about the size of the file and the block size.
-    fn tree(&self) -> BaoTree;
-    /// load the hash pair for a node
-    fn load(&self, node: TreeNode) -> io::Result<Option<(blake3::Hash, blake3::Hash)>>;
-}
-
-pub trait OutboardMut: Outboard {
-    /// Set the length of the file for which this outboard is
-    fn set_size(&mut self, len: ByteNum) -> io::Result<()>;
-    /// Save a hash pair for a node
-    fn save(&mut self, node: TreeNode, hash_pair: &(blake3::Hash, blake3::Hash)) -> io::Result<()>;
-}
-
-impl<O: Outboard> Outboard for &O {
-    fn root(&self) -> blake3::Hash {
-        (**self).root()
-    }
-    fn tree(&self) -> BaoTree {
-        (**self).tree()
-    }
-    fn load(&self, node: TreeNode) -> io::Result<Option<(blake3::Hash, blake3::Hash)>> {
-        (**self).load(node)
-    }
-}
-
-impl<O: Outboard> Outboard for &mut O {
-    fn root(&self) -> blake3::Hash {
-        (**self).root()
-    }
-    fn tree(&self) -> BaoTree {
-        (**self).tree()
-    }
-    fn load(&self, node: TreeNode) -> io::Result<Option<(blake3::Hash, blake3::Hash)>> {
-        (**self).load(node)
-    }
-}
-
-impl<O: OutboardMut> OutboardMut for &mut O {
-    fn save(&mut self, node: TreeNode, hash_pair: &(blake3::Hash, blake3::Hash)) -> io::Result<()> {
-        (**self).save(node, hash_pair)
-    }
-    fn set_size(&mut self, len: ByteNum) -> io::Result<()> {
-        (**self).set_size(len)
-    }
-}
-
-/// Given an outboard, return a range set of all valid ranges
-pub fn valid_ranges<O>(outboard: &O) -> io::Result<RangeSet2<ChunkNum>>
-where
-    O: Outboard,
-{
-    struct RecursiveValidator<'a, O: Outboard> {
-        tree: BaoTree,
-        valid_nodes: TreeNode,
-        res: RangeSet2<ChunkNum>,
-        outboard: &'a O,
-    }
-
-    impl<'a, O: Outboard> RecursiveValidator<'a, O> {
-        fn validate_rec(
-            &mut self,
-            parent_hash: &blake3::Hash,
-            node: TreeNode,
-            is_root: bool,
-        ) -> io::Result<()> {
-            let (l_hash, r_hash) = if let Some((l_hash, r_hash)) = self.outboard.load(node)? {
-                let actual = parent_cv(&l_hash, &r_hash, is_root);
-                if &actual != parent_hash {
-                    // we got a validation error. Simply continue without adding the range
-                    return Ok(());
-                }
-                (l_hash, r_hash)
-            } else {
-                (*parent_hash, blake3::Hash::from([0; 32]))
-            };
-            if let Some(leaf) = node.as_leaf() {
-                let start = self.tree.chunk_num(leaf);
-                let end = (start + self.tree.chunk_group_chunks() * 2).min(self.tree.chunks());
-                self.res |= RangeSet2::from(start..end);
-            } else {
-                // recurse
-                let left = node.left_child().unwrap();
-                self.validate_rec(&l_hash, left, false)?;
-                let right = node.right_descendant(self.valid_nodes).unwrap();
-                self.validate_rec(&r_hash, right, false)?;
-            }
-            Ok(())
-        }
-    }
-    let tree = outboard.tree();
-    let root_hash = outboard.root();
-    let mut validator = RecursiveValidator {
-        tree,
-        valid_nodes: tree.filled_size(),
-        res: RangeSet2::empty(),
-        outboard,
-    };
-    validator.validate_rec(&root_hash, tree.root(), true)?;
-    Ok(validator.res)
 }
 
 /// An empty outboard, that just returns 0 hashes for all nodes.
@@ -132,7 +26,7 @@ impl EmptyOutboard {
     }
 }
 
-impl Outboard for EmptyOutboard {
+impl crate::io::sync::Outboard for EmptyOutboard {
     fn root(&self) -> blake3::Hash {
         self.root
     }
@@ -149,7 +43,25 @@ impl Outboard for EmptyOutboard {
     }
 }
 
-impl OutboardMut for EmptyOutboard {
+impl crate::io::fsm::Outboard for EmptyOutboard {
+    fn root(&self) -> blake3::Hash {
+        self.root
+    }
+    fn tree(&self) -> BaoTree {
+        self.tree
+    }
+    type LoadFuture<'a> = futures::future::Ready<io::Result<Option<(blake3::Hash, blake3::Hash)>>>;
+    fn load(&self, node: TreeNode) -> Self::LoadFuture<'_> {
+        futures::future::ok(if self.tree.is_persisted(node) {
+            // behave as if it was an outboard file filled with 0s
+            Some((blake3::Hash::from([0; 32]), blake3::Hash::from([0; 32])))
+        } else {
+            None
+        })
+    }
+}
+
+impl crate::io::sync::OutboardMut for EmptyOutboard {
     fn save(&mut self, node: TreeNode, _pair: &(blake3::Hash, blake3::Hash)) -> io::Result<()> {
         if self.tree.is_persisted(node) {
             Ok(())
@@ -215,7 +127,7 @@ impl<'a> PostOrderMemOutboardRef<'a> {
     }
 }
 
-impl<'a> Outboard for PostOrderMemOutboardRef<'a> {
+impl<'a> crate::io::sync::Outboard for PostOrderMemOutboardRef<'a> {
     fn root(&self) -> blake3::Hash {
         self.root
     }
@@ -224,6 +136,20 @@ impl<'a> Outboard for PostOrderMemOutboardRef<'a> {
     }
     fn load(&self, node: TreeNode) -> io::Result<Option<(blake3::Hash, blake3::Hash)>> {
         Ok(load_raw_post_mem(&self.tree, self.data, node).map(parse_hash_pair))
+    }
+}
+
+impl<'a> crate::io::fsm::Outboard for PostOrderMemOutboardRef<'a> {
+    fn root(&self) -> blake3::Hash {
+        self.root
+    }
+    fn tree(&self) -> BaoTree {
+        self.tree
+    }
+    type LoadFuture<'b> = futures::future::Ready<io::Result<Option<(blake3::Hash, blake3::Hash)>>>
+        where 'a: 'b;
+    fn load(&self, node: TreeNode) -> Self::LoadFuture<'_> {
+        futures::future::ok(load_raw_post_mem(&self.tree, self.data, node).map(parse_hash_pair))
     }
 }
 
@@ -296,7 +222,7 @@ impl PostOrderMemOutboard {
     }
 }
 
-impl Outboard for PostOrderMemOutboard {
+impl crate::io::sync::Outboard for PostOrderMemOutboard {
     fn root(&self) -> blake3::Hash {
         self.root
     }
@@ -308,7 +234,20 @@ impl Outboard for PostOrderMemOutboard {
     }
 }
 
-impl OutboardMut for PostOrderMemOutboard {
+impl crate::io::fsm::Outboard for PostOrderMemOutboard {
+    fn root(&self) -> blake3::Hash {
+        self.root
+    }
+    fn tree(&self) -> BaoTree {
+        self.tree
+    }
+    type LoadFuture<'a> = futures::future::Ready<io::Result<Option<(blake3::Hash, blake3::Hash)>>>;
+    fn load(&self, node: TreeNode) -> Self::LoadFuture<'_> {
+        crate::io::fsm::Outboard::load(&self.as_outboard_ref(), node)
+    }
+}
+
+impl crate::io::sync::OutboardMut for PostOrderMemOutboard {
     fn save(&mut self, node: TreeNode, pair: &(blake3::Hash, blake3::Hash)) -> io::Result<()> {
         match self.tree.post_order_offset(node) {
             Some(offset) => {
@@ -403,7 +342,7 @@ impl<'a> PreOrderMemOutboardRef<'a> {
     }
 }
 
-impl<'a> Outboard for PreOrderMemOutboardRef<'a> {
+impl<'a> crate::io::sync::Outboard for PreOrderMemOutboardRef<'a> {
     fn root(&self) -> blake3::Hash {
         self.root
     }
@@ -412,6 +351,21 @@ impl<'a> Outboard for PreOrderMemOutboardRef<'a> {
     }
     fn load(&self, node: TreeNode) -> io::Result<Option<(blake3::Hash, blake3::Hash)>> {
         Ok(load_raw_pre_mem(&self.tree, self.data, node).map(parse_hash_pair))
+    }
+}
+
+impl<'a> crate::io::fsm::Outboard for PreOrderMemOutboardRef<'a> {
+    fn root(&self) -> blake3::Hash {
+        self.root
+    }
+    fn tree(&self) -> BaoTree {
+        self.tree
+    }
+    type LoadFuture<'b> = futures::future::Ready<io::Result<Option<(blake3::Hash, blake3::Hash)>>>
+        where
+            'a: 'b;
+    fn load(&self, node: TreeNode) -> Self::LoadFuture<'_> {
+        futures::future::ok(load_raw_pre_mem(&self.tree, self.data, node).map(parse_hash_pair))
     }
 }
 
@@ -524,7 +478,7 @@ fn parse_hash_pair(buf: [u8; 64]) -> (blake3::Hash, blake3::Hash) {
     (l_hash, r_hash)
 }
 
-impl OutboardMut for PreOrderMemOutboard {
+impl crate::io::sync::OutboardMut for PreOrderMemOutboard {
     fn save(&mut self, node: TreeNode, pair: &(blake3::Hash, blake3::Hash)) -> io::Result<()> {
         match self.tree.pre_order_offset(node) {
             Some(offset) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,14 +9,16 @@ use proptest::prelude::*;
 use range_collections::{RangeSet2, RangeSetRef};
 use smallvec::SmallVec;
 
-use crate::io::{DecodeResponseItem, Leaf};
+use crate::io::{
+    sync::{valid_ranges, Outboard},
+    DecodeResponseItem, Leaf,
+};
 
 use super::{
     canonicalize_range,
     io::sync::{encode_ranges, encode_ranges_validated, DecodeResponseIter},
     iter::{BaoChunk, NodeInfo},
-    outboard::{valid_ranges, Outboard, PostOrderMemOutboardRef},
-    outboard::{PostOrderMemOutboard, PreOrderMemOutboard},
+    outboard::{PostOrderMemOutboard, PostOrderMemOutboardRef, PreOrderMemOutboard},
     pre_order_offset_slow,
     tree::{ByteNum, ChunkNum},
     BaoTree, BlockSize, PostOrderNodeIter, TreeNode,


### PR DESCRIPTION
this will allow having an outboard that is not in memory and not available via sync calls, such as from a http resource.