### PR TITLE
feat: make it possible to choose the non simd subtree hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ version = "0.6.3"
 dependencies = [
  "abao 0.2.0 (git+https://github.com/n0-computer/abao?branch=post-order-outboard)",
  "bao",
+ "blake3",
  "bytes",
  "criterion",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["data-structures"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iroh-blake3 = "1.4.3"
+iroh-blake3 = { version = "1.4.3", optional = true }
+blake3 = { version = "1.4.1", optional = true }
 range-collections = "0.4.1"
 smallvec = "1"
 
@@ -25,7 +26,9 @@ positioned-io = { version = "0.3.1", default_features = false }
 
 [features]
 tokio_fsm = ["tokio", "futures", "iroh-io"]
-default = ["tokio_fsm"]
+default = ["tokio_fsm", "simd_subtree_hash"]
+simd_subtree_hash = ["iroh-blake3"]
+recursive_subtree_hash = ["blake3"]
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,17 +32,23 @@ use iter::*;
 use tree::BlockNum;
 pub use tree::{BlockSize, ByteNum, ChunkNum};
 pub mod io;
+#[cfg(feature = "recursive_subtree_hash")]
+pub use blake3;
+#[cfg(feature = "simd_subtree_hash")]
 pub use iroh_blake3 as blake3;
 
 #[cfg(test)]
 mod tests;
 
 fn hash_subtree(start_chunk: u64, data: &[u8], is_root: bool) -> blake3::Hash {
+    #[cfg(feature = "simd_subtree_hash")]
     if data.len().is_power_of_two() {
         blake3::guts::hash_subtree(start_chunk, data, is_root)
     } else {
         recursive_hash_subtree(start_chunk, data, is_root)
     }
+    #[cfg(feature = "recursive_subtree_hash")]
+    recursive_hash_subtree(start_chunk, data, is_root)
 }
 
 /// This is a recursive version of [`hash_subtree`], for testing.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -441,6 +441,7 @@ fn outboard_wrong_hash() {
     assert_eq!(expected, actual);
 }
 
+#[cfg(feature = "simd_subtree_hash")]
 #[test]
 #[ignore]
 fn wrong_hash_small() {


### PR DESCRIPTION
in this case we can depend on upstream blake3 instead of iroh-blake3