### PR TITLE
Better decode error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "abao 0.2.0 (git+https://github.com/n0-computer/abao?branch=post-order-outboard)",
  "bao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bao-tree"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 description = "BLAKE3 verfiied streaming with custom chunk groups and range set queries"
 license = "MIT OR Apache-2.0"

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -41,15 +41,93 @@ impl From<StartDecodeError> for io::Error {
     }
 }
 
-/// Error when decoding from a reader
+/// Error when decoding from a reader, both when reading the size and after
 ///
-/// This can either be a io error or a more specific error like a hash mismatch
+/// This is an union of [`StartDecodeError`] and [`DecodeError`] for convenience.
 #[derive(Debug)]
-pub enum DecodeError {
+pub enum AnyDecodeError {
     /// We got an EOF when reading the size, indicating that the remote end does not have the blob
     NotFound,
     /// The query range was invalid
     InvalidQueryRange,
+    /// We got an EOF while reading a parent hash pair, indicating that the remote end does not have the outboard
+    ParentNotFound(TreeNode),
+    /// We got an EOF while reading a chunk, indicating that the remote end does not have the data
+    LeafNotFound(ChunkNum),
+    /// The hash of a parent did not match the expected hash
+    ParentHashMismatch(TreeNode),
+    /// The hash of a leaf did not match the expected hash
+    LeafHashMismatch(ChunkNum),
+    /// There was an error reading from the underlying io
+    Io(io::Error),
+}
+
+impl From<DecodeError> for AnyDecodeError {
+    fn from(e: DecodeError) -> Self {
+        match e {
+            DecodeError::Io(e) => Self::Io(e),
+            DecodeError::ParentHashMismatch(node) => Self::ParentHashMismatch(node),
+            DecodeError::LeafHashMismatch(chunk) => Self::LeafHashMismatch(chunk),
+            DecodeError::LeafNotFound(chunk) => Self::LeafNotFound(chunk),
+            DecodeError::ParentNotFound(node) => Self::ParentNotFound(node),
+        }
+    }
+}
+
+impl From<StartDecodeError> for AnyDecodeError {
+    fn from(e: StartDecodeError) -> Self {
+        match e {
+            StartDecodeError::Io(e) => Self::Io(e),
+            StartDecodeError::InvalidQueryRange => Self::InvalidQueryRange,
+            StartDecodeError::NotFound => Self::NotFound,
+        }
+    }
+}
+
+impl fmt::Display for AnyDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for AnyDecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<AnyDecodeError> for io::Error {
+    fn from(e: AnyDecodeError) -> Self {
+        match e {
+            AnyDecodeError::Io(e) => e,
+            AnyDecodeError::ParentHashMismatch(node) => io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parent hash mismatch (level {}, block {})",
+                    node.level(),
+                    node.mid().0
+                ),
+            ),
+            AnyDecodeError::LeafHashMismatch(chunk) => io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("leaf hash mismatch (offset {})", chunk.to_bytes().0),
+            ),
+            AnyDecodeError::InvalidQueryRange => {
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid query range")
+            }
+            AnyDecodeError::LeafNotFound(_) => io::Error::new(io::ErrorKind::UnexpectedEof, e),
+            AnyDecodeError::ParentNotFound(_) => io::Error::new(io::ErrorKind::UnexpectedEof, e),
+            AnyDecodeError::NotFound => io::Error::new(io::ErrorKind::UnexpectedEof, e),
+        }
+    }
+}
+
+/// Error when decoding from a reader, after the size has been read
+#[derive(Debug)]
+pub enum DecodeError {
     /// We got an EOF while reading a parent hash pair, indicating that the remote end does not have the outboard
     ParentNotFound(TreeNode),
     /// We got an EOF while reading a chunk, indicating that the remote end does not have the data
@@ -93,19 +171,9 @@ impl From<DecodeError> for io::Error {
                 io::ErrorKind::InvalidData,
                 format!("leaf hash mismatch (offset {})", chunk.to_bytes().0),
             ),
-            DecodeError::InvalidQueryRange => {
-                io::Error::new(io::ErrorKind::InvalidInput, "invalid query range")
-            }
             DecodeError::LeafNotFound(_) => io::Error::new(io::ErrorKind::UnexpectedEof, e),
             DecodeError::ParentNotFound(_) => io::Error::new(io::ErrorKind::UnexpectedEof, e),
-            DecodeError::NotFound => io::Error::new(io::ErrorKind::UnexpectedEof, e),
         }
-    }
-}
-
-impl From<io::Error> for DecodeError {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
     }
 }
 

--- a/src/io/error.rs
+++ b/src/io/error.rs
@@ -9,14 +9,14 @@ use std::{fmt, io};
 /// This can either be a io error or a more specific error like a hash mismatch
 #[derive(Debug)]
 pub enum DecodeError {
-    /// There was an error reading from the underlying io
-    Io(io::Error),
     /// The hash of a parent did not match the expected hash
     ParentHashMismatch(TreeNode),
     /// The hash of a leaf did not match the expected hash
     LeafHashMismatch(ChunkNum),
     /// The query range was invalid
     InvalidQueryRange,
+    /// There was an error reading from the underlying io
+    Io(io::Error),
 }
 
 impl fmt::Display for DecodeError {

--- a/src/io/fsm.rs
+++ b/src/io/fsm.rs
@@ -17,7 +17,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
     io::{
-        error::{DecodeError, EncodeError},
+        error::EncodeError,
         outboard::{PostOrderOutboard, PreOrderOutboard},
         Leaf, Parent,
     },
@@ -26,7 +26,7 @@ use crate::{
 };
 pub use iroh_io::{AsyncSliceReader, AsyncSliceWriter};
 
-use super::StartDecodeError;
+use super::{DecodeError, StartDecodeError};
 
 /// An item of bao content
 ///
@@ -289,7 +289,9 @@ impl<'a, R: AsyncRead + Unpin> ResponseDecoderStart<R> {
     /// Read the size and go into the next state
     ///
     /// The only thing that can go wrong here is an io error when reading the size.
-    pub async fn next(self) -> std::result::Result<(ResponseDecoderReading<R>, u64), StartDecodeError> {
+    pub async fn next(
+        self,
+    ) -> std::result::Result<(ResponseDecoderReading<R>, u64), StartDecodeError> {
         let Self {
             ranges,
             block_size,

--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::hash_subtree;
 use crate::{
     blake3,
-    io::error::{DecodeError, EncodeError},
+    io::error::{AnyDecodeError, EncodeError},
     io::{
         outboard::{parse_hash_pair, PostOrderMemOutboard, PostOrderOutboard, PreOrderOutboard},
         Header, Leaf, Parent,
@@ -382,7 +382,7 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
         }
     }
 
-    fn next0(&mut self) -> result::Result<Option<DecodeResponseItem>, DecodeError> {
+    fn next0(&mut self) -> result::Result<Option<DecodeResponseItem>, AnyDecodeError> {
         let inner = match &mut self.inner {
             Position::Content { ref mut iter } => iter,
             Position::Header {
@@ -391,14 +391,14 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
             } => {
                 let size = read_len(&mut self.encoded).map_err(|e| {
                     if e.kind() == io::ErrorKind::UnexpectedEof {
-                        DecodeError::NotFound
+                        AnyDecodeError::NotFound
                     } else {
-                        DecodeError::Io(e)
+                        AnyDecodeError::Io(e)
                     }
                 })?;
                 // make sure the range is valid and canonical
                 if !range_ok(range, size.chunks()) {
-                    return Err(DecodeError::InvalidQueryRange);
+                    return Err(AnyDecodeError::InvalidQueryRange);
                 }
                 let tree = BaoTree::new(size, *block_size);
                 self.inner = Position::Content {
@@ -416,15 +416,15 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
             }) => {
                 let pair @ (l_hash, r_hash) = read_parent(&mut self.encoded).map_err(|e| {
                     if e.kind() == io::ErrorKind::UnexpectedEof {
-                        DecodeError::ParentNotFound(node)
+                        AnyDecodeError::ParentNotFound(node)
                     } else {
-                        DecodeError::Io(e)
+                        AnyDecodeError::Io(e)
                     }
                 })?;
                 let parent_hash = self.stack.pop().unwrap();
                 let actual = parent_cv(&l_hash, &r_hash, is_root);
                 if parent_hash != actual {
-                    return Err(DecodeError::ParentHashMismatch(node));
+                    return Err(AnyDecodeError::ParentHashMismatch(node));
                 }
                 if right {
                     self.stack.push(r_hash);
@@ -442,15 +442,15 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
                 self.buf.resize(size, 0);
                 self.encoded.read_exact(&mut self.buf).map_err(|e| {
                     if e.kind() == io::ErrorKind::UnexpectedEof {
-                        DecodeError::LeafNotFound(start_chunk)
+                        AnyDecodeError::LeafNotFound(start_chunk)
                     } else {
-                        DecodeError::Io(e)
+                        AnyDecodeError::Io(e)
                     }
                 })?;
                 let actual = hash_subtree(start_chunk.0, &self.buf, is_root);
                 let leaf_hash = self.stack.pop().unwrap();
                 if leaf_hash != actual {
-                    return Err(DecodeError::LeafHashMismatch(start_chunk));
+                    return Err(AnyDecodeError::LeafHashMismatch(start_chunk));
                 }
                 Ok(Some(
                     Leaf {
@@ -466,7 +466,7 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
 }
 
 impl<'a, R: Read> Iterator for DecodeResponseIter<'a, R> {
-    type Item = result::Result<DecodeResponseItem, DecodeError>;
+    type Item = result::Result<DecodeResponseItem, AnyDecodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next0().transpose()

--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -389,7 +389,16 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
                 block_size,
                 ranges: range,
             } => {
-                let size = read_len(&mut self.encoded)?;
+                let size = match read_len(&mut self.encoded) {
+                    Ok(size) => size,
+                    Err(e) => {
+                        return Err(if e.kind() == io::ErrorKind::UnexpectedEof {
+                            DecodeError::NotFound
+                        } else {
+                            DecodeError::Io(e)
+                        });
+                    }
+                };
                 // make sure the range is valid and canonical
                 if !range_ok(range, size.chunks()) {
                     return Err(DecodeError::InvalidQueryRange);
@@ -408,7 +417,16 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
                 right,
                 node,
             }) => {
-                let pair @ (l_hash, r_hash) = read_parent(&mut self.encoded)?;
+                let pair @ (l_hash, r_hash) = match read_parent(&mut self.encoded) {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        return Err(if e.kind() == io::ErrorKind::UnexpectedEof {
+                            DecodeError::ParentNotFound(node)
+                        } else {
+                            DecodeError::Io(e)
+                        });
+                    }
+                };
                 let parent_hash = self.stack.pop().unwrap();
                 let actual = parent_cv(&l_hash, &r_hash, is_root);
                 if parent_hash != actual {
@@ -428,7 +446,13 @@ impl<'a, R: Read> DecodeResponseIter<'a, R> {
                 start_chunk,
             }) => {
                 self.buf.resize(size, 0);
-                self.encoded.read_exact(&mut self.buf)?;
+                if let Err(e) = self.encoded.read_exact(&mut self.buf) {
+                    return Err(if e.kind() == io::ErrorKind::UnexpectedEof {
+                        DecodeError::LeafNotFound(start_chunk)
+                    } else {
+                        DecodeError::Io(e)
+                    });
+                }
                 let actual = hash_subtree(start_chunk.0, &self.buf, is_root);
                 let leaf_hash = self.stack.pop().unwrap();
                 if leaf_hash != actual {


### PR DESCRIPTION
TLDR: if you read something and get an EOF, produce a specific error noting whatever it was you were doing at the time, which allows you to know where exactly the failure was.

These errors don't contain the hash, since bao-tree only concerns itself with individual blobs.