### PR TITLE
proper non self contained trees

### DIFF
--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -649,7 +649,7 @@ pub fn outboard_post_order(
     block_size: BlockSize,
     mut outboard: impl Write,
 ) -> io::Result<blake3::Hash> {
-    let tree = BaoTree::new_with_start_chunk(ByteNum(size), block_size, ChunkNum(0));
+    let tree = BaoTree::new(ByteNum(size), block_size);
     let mut buffer = vec![0; tree.chunk_group_bytes().to_usize()];
     let hash = outboard_post_order_impl(tree, data, &mut outboard, &mut buffer)?;
     outboard.write_all(&size.to_le_bytes())?;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -64,7 +64,7 @@ impl<'a> PreOrderPartialIterRef<'a> {
             tree_filled_size: tree.filled_size(),
             max_skip_level,
             stack,
-            is_root: tree.start_chunk == 0,
+            is_root: tree.is_root,
         }
     }
 


### PR DESCRIPTION
start_chunk can not be used to check if a tree is self-contained. a tree can have a start chunk of 0 and still be non-root