### PR TITLE
change the way subtrees are handled, again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub struct BaoTree {
     /// true if this is a self-contained tree, false if it is part of a larger tree
     is_root: bool,
     /// start chunk of the tree, can only be non-zero if this is not a self-contained tree
-    start_chunk: ChunkNum,
+    root: TreeNode,
 }
 
 /// An offset of a node in a post-order outboard
@@ -105,7 +105,9 @@ impl BaoTree {
 
     /// Create a new BaoTree
     pub fn new(size: ByteNum, block_size: BlockSize) -> Self {
-        Self::new_with_start_chunk(size, block_size, true, ChunkNum(0))
+        // compute the root from the size and block size
+        let root = TreeNode::root(size.blocks(block_size).max(BlockNum(1)));
+        Self::new_with_root(size, block_size, root, true)
     }
 
     /// Compute the post order outboard for the given data, returning a in mem data structure
@@ -133,6 +135,12 @@ impl BaoTree {
         let start = node.block_range().start.to_bytes(self.block_size);
         let end = node.block_range().end.to_bytes(self.block_size);
         start..end.min(self.size)
+    }
+
+    fn chunk_range(&self, node: TreeNode) -> Range<ChunkNum> {
+        let start = node.block_range().start.to_chunks(self.block_size);
+        let end = node.block_range().end.to_chunks(self.block_size);
+        start..end.min(self.size.chunks())
     }
 
     /// Compute the byte ranges for a leaf node
@@ -203,38 +211,45 @@ impl BaoTree {
     /// The start chunk is the chunk number of the first chunk in the tree.
     ///
     /// This is mostly used internally.
-    pub fn new_with_start_chunk(
+    pub fn new_with_root(
         size: ByteNum,
         block_size: BlockSize,
+        root: TreeNode,
         is_root: bool,
-        start_chunk: ChunkNum,
     ) -> Self {
-        debug_assert!((start_chunk == 0) || !is_root);
         Self {
             size,
             block_size,
-            start_chunk,
+            root,
             is_root,
         }
     }
 
     /// Root of the tree
+    ///
+    /// For a self-contained tree, this is the global root of the tree.
+    /// For a tree that is part of a larger tree, this is the root of the
+    /// subtree that this tree represents.
     pub fn root(&self) -> TreeNode {
-        TreeNode::root(self.blocks())
+        self.root
     }
 
     /// Number of blocks in the tree
     ///
     /// At chunk group size 1, this is the same as the number of chunks
-    /// Even a tree with 0 bytes size has a single block
+    /// Even a tree with 0 bytes size has a single block.
     pub fn blocks(&self) -> BlockNum {
+        let range = self.root.block_range();
+        let min = range.start;
+        let max = range.end.min(self.size.blocks(self.block_size));
         // handle the case of an empty tree having 1 block
-        self.size.blocks(self.block_size).max(BlockNum(1))
+        (max - min).max(BlockNum(1))
     }
 
     /// Number of chunks in the tree
     pub fn chunks(&self) -> ChunkNum {
-        self.size.chunks()
+        let range = self.chunk_range(self.root);
+        range.end - range.start
     }
 
     /// Number of hash pairs in the outboard
@@ -257,7 +272,7 @@ impl BaoTree {
     pub const fn chunk_num(&self, node: LeafNode) -> ChunkNum {
         // block number of a leaf node is just the node number
         // multiply by chunk_group_size to get the chunk number
-        ChunkNum((node.0 << self.block_size.0) + self.start_chunk.0)
+        ChunkNum(node.0 << self.block_size.0)
     }
 
     /// true if the given node is complete/sealed

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -737,13 +737,12 @@ fn iterate_part_preorder_reference<'a>(
         }
     }
     let mut res = Vec::new();
-    let can_be_root = tree.start_chunk == 0;
     iterate_part_rec(
         tree,
         tree.root(),
         ranges,
         max_skip_level as u32,
-        can_be_root,
+        tree.is_root,
         &mut res,
     );
     res


### PR DESCRIPTION
We now explicitly store the root. This is less error prone than having a chunk offset, since the chunk offset would have to be considered everywhere where we work with chunks and bytes etc.