### PR TITLE
Fix sub chunk group bug

### DIFF
--- a/proptest-regressions/rec.txt
+++ b/proptest-regressions/rec.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 75f46a82c8f8435fade48450ebabd5bbd329c32b26c5004d12ef7b1dae1014cb # shrinks to input = _OutboardBaoComparisonArgs { size: 0 }
 cc 211d7cee651c01b102bc7ecb9651e5a138cfc31a908202896b45622cd3dbc606 # shrinks to input = _BaoEncodeSliceComparisonArgs { size_and_slice: (1, 0..0) }
+cc a02ccf617472ec9247772e645611c3fafb61a62e36cb0df863621bbb18bbbf5e # shrinks to input = _BaoEncodeSliceComparisonArgs { size_and_slice: (1038, 0..1) }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -90,10 +90,8 @@ impl<'a> Iterator for PreOrderPartialIterRef<'a> {
             let node = shifted.subtract_block_size(tree.block_size.0);
             let is_half_leaf = !tree.is_persisted(node);
             let (l_ranges, r_ranges) = if !is_half_leaf {
-                // the middle chunk of the node
-                let mid = node.mid();
                 // split the ranges into left and right
-                split(ranges, mid)
+                split(ranges, node)
             } else {
                 (ranges, ranges)
             };
@@ -551,7 +549,6 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
         let node = shifted.subtract_block_size(tree.block_size.0);
         // we don't want to recurse if the node is full and below the minimum level
         let ranges_is_all = ranges.is_all();
-        println!("{:?} {}", ranges, node.level());
         let below_min_full_level = node.level() < self.min_full_level as u32;
         let query_leaf = ranges_is_all && below_min_full_level;
         // check if the node is the root by comparing the shifted node to the shifted root
@@ -575,14 +572,7 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
         } else if !shifted.is_leaf() {
             // The node is either not fully within the query range, or it's level is above
             // min_full_level. In this case we need to recurse.
-            let (l_ranges, r_ranges) = split(ranges, node.mid());
-            println!(
-                "split {:?} {} {:?} {:?}",
-                ranges,
-                node.mid(),
-                l_ranges,
-                r_ranges
-            );
+            let (l_ranges, r_ranges) = split(ranges, node);
             // emit right child first, so it gets yielded last
             if !r_ranges.is_empty() {
                 let r = shifted.right_descendant(self.shifted_filled_size).unwrap();
@@ -622,7 +612,7 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
                     ranges,
                 })
             } else {
-                let (l_ranges, r_ranges) = split(ranges, node.mid());
+                let (l_ranges, r_ranges) = split(ranges, node);
                 // emit right range first, so it gets yielded last
                 if !r_ranges.is_empty() {
                     self.buffer.push(BaoChunk::Leaf {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -576,7 +576,13 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
             // The node is either not fully within the query range, or it's level is above
             // min_full_level. In this case we need to recurse.
             let (l_ranges, r_ranges) = split(ranges, node.mid());
-            println!("split {:?} {} {:?} {:?}", ranges, node.mid(), l_ranges, r_ranges);
+            println!(
+                "split {:?} {} {:?} {:?}",
+                ranges,
+                node.mid(),
+                l_ranges,
+                r_ranges
+            );
             // emit right child first, so it gets yielded last
             if !r_ranges.is_empty() {
                 let r = shifted.right_descendant(self.shifted_filled_size).unwrap();

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -550,7 +550,10 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
         debug_assert!(!ranges.is_empty());
         let node = shifted.subtract_block_size(tree.block_size.0);
         // we don't want to recurse if the node is full and below the minimum level
-        let query_leaf = ranges.is_all() && node.level() < self.min_full_level as u32;
+        let ranges_is_all = ranges.is_all();
+        println!("{:?} {}", ranges, node.level());
+        let below_min_full_level = node.level() < self.min_full_level as u32;
+        let query_leaf = ranges_is_all && below_min_full_level;
         // check if the node is the root by comparing the shifted node to the shifted root
         let is_root = shifted == self.shifted_root;
         let chunk_range = node.chunk_range();
@@ -573,6 +576,7 @@ impl<'a> Iterator for PreOrderPartialChunkIterRef<'a> {
             // The node is either not fully within the query range, or it's level is above
             // min_full_level. In this case we need to recurse.
             let (l_ranges, r_ranges) = split(ranges, node.mid());
+            println!("split {:?} {} {:?} {:?}", ranges, node.mid(), l_ranges, r_ranges);
             // emit right child first, so it gets yielded last
             if !r_ranges.is_empty() {
                 let r = shifted.right_descendant(self.shifted_filled_size).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,7 +655,8 @@ fn pre_order_offset_loop(node: u64, len: u64) -> u64 {
 /// Split a range set into range sets for the left and right half of a node
 ///
 /// Requires that the range set is minimal, it should not contain any redundant
-/// boundaries outside of the range of the node.
+/// boundaries outside of the range of the node. The values outside of the node
+/// range don't matter, so any change outside the range must be omitted.
 ///
 /// Produces two range sets that are also minimal. A range set for left or right
 /// that covers the entire range of the node will be replaced with the set of

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -459,10 +459,13 @@ mod tests {
         ops::Range,
     };
 
-    use crate::{BlockSize, ByteNum, ChunkRanges};
+    use crate::{
+        rec::{
+            bao_encode_reference, bao_outboard_reference, encode_ranges_reference, make_test_data,
+        },
+        BlockSize, ByteNum, ChunkRanges,
+    };
     use proptest::prelude::*;
-
-    use super::*;
 
     fn size_and_slice() -> impl Strategy<Value = (usize, Range<usize>)> {
         (1..100000usize)

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -2,10 +2,7 @@
 //!
 //! Encocding is used to compute hashes, decoding is only used in tests as a
 //! reference implementation.
-use crate::{blake3, split, ByteNum, ChunkNum, ChunkRanges, ChunkRangesRef};
-
-#[cfg(test)]
-use crate::{iter::BaoChunk, BaoTree, BlockSize, TreeNode};
+use crate::{blake3, split_inner, ByteNum, ChunkNum, ChunkRanges, ChunkRangesRef};
 
 /// Given a set of chunk ranges, adapt them for a tree of the given size.
 ///
@@ -122,7 +119,7 @@ pub(crate) fn encode_selected_rec(
         let mid = chunks / 2;
         let mid_bytes = mid * CHUNK_LEN;
         let mid_chunk = start_chunk + (mid as u64);
-        let (l_ranges, r_ranges) = split(query, mid_chunk);
+        let (l_ranges, r_ranges) = split_inner(query, start_chunk, mid_chunk);
         // for empty ranges, we don't want to emit anything.
         // for full ranges where the level is below min_level, we want to emit
         // just the data.
@@ -167,13 +164,17 @@ pub(crate) fn encode_selected_rec(
 
 #[cfg(test)]
 mod test_support {
+    use crate::blake3;
     use std::ops::Range;
 
     use range_collections::{range_set::RangeSetEntry, RangeSet2};
 
-    use crate::{ByteNum, ChunkRanges};
+    use crate::{
+        split_inner, BaoChunk, BaoTree, BlockSize, ByteNum, ChunkNum, ChunkRanges, ChunkRangesRef,
+        TreeNode,
+    };
 
-    use super::*;
+    use super::{encode_selected_rec, truncate_ranges};
 
     /// Select nodes relevant to a query
     ///
@@ -232,7 +233,7 @@ mod test_support {
                 let mid = chunks / 2;
                 let mid_bytes = mid * CHUNK_LEN;
                 let mid_chunk = start_chunk + (mid as u64);
-                let (l_ranges, r_ranges) = split(ranges, mid_chunk);
+                let (l_ranges, r_ranges) = split_inner(ranges, start_chunk, mid_chunk);
                 let node =
                     TreeNode::from_start_chunk_and_level(start_chunk, BlockSize(level as u8));
                 emit(BaoChunk::Parent {
@@ -458,7 +459,7 @@ mod tests {
         ops::Range,
     };
 
-    use crate::{ByteNum, ChunkRanges};
+    use crate::{BlockSize, ByteNum, ChunkRanges};
     use proptest::prelude::*;
 
     use super::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -918,10 +918,7 @@ fn sub_chunk_group_query() {
     let tree = BaoTree::new(ByteNum(1024 * 32), BlockSize(4));
     let ranges = ChunkRanges::from(ChunkNum(16)..ChunkNum(24));
     let items = ResponseIter::new(tree, ranges)
-        .filter_map(|x| match x {
-            BaoChunk::Leaf { .. } => Some(x),
-            _ => None,
-        })
+        .filter(|x| matches!(x, BaoChunk::Leaf { .. }))
         .collect::<Vec<_>>();
     assert_eq!(items.len(), 1);
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -921,12 +921,12 @@ fn sub_chunk_group_query() {
     let ranges = ChunkRanges::from(ChunkNum(16)..ChunkNum(24));
     let items = ResponseIter::new(tree, ranges)
         .filter_map(|x| match x {
-                BaoChunk::Leaf { .. } => Some(x),
-                _ => None,
-            }
-        )
+            BaoChunk::Leaf { .. } => Some(x),
+            _ => None,
+        })
         .collect::<Vec<_>>();
-    println!("{:?}", items);
+    // this should be just 1 leaf of size 8 chunks, but it gets split into 4
+    assert_eq!(items.len(), 1);
 }
 
 proptest! {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -557,13 +557,11 @@ fn iterate_part_preorder_reference<'a>(
             return;
         }
         let is_half_leaf = !tree.is_relevant_for_outboard(node);
-        // the middle chunk of the node
-        let mid = node.mid();
         // check if the node is fully included
         let full = ranges.is_all();
         // split the ranges into left and right
         let (l_ranges, r_ranges) = if !is_half_leaf {
-            split(ranges, mid)
+            split(ranges, node)
         } else {
             (ranges, ranges)
         };
@@ -925,7 +923,6 @@ fn sub_chunk_group_query() {
             _ => None,
         })
         .collect::<Vec<_>>();
-    // this should be just 1 leaf of size 8 chunks, but it gets split into 4
     assert_eq!(items.len(), 1);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ use crate::{
         encode_ranges_reference, encode_selected_rec, make_test_data, range_union, truncate_ranges,
         ReferencePreOrderPartialChunkIterRef,
     },
-    recursive_hash_subtree, split, ChunkRanges, ChunkRangesRef,
+    recursive_hash_subtree, split, ChunkRanges, ChunkRangesRef, ResponseIter,
 };
 
 use super::{
@@ -913,6 +913,20 @@ fn encode_last_chunk_cases() {
     for (size, block_size) in cases {
         assert_tuple_eq!(encode_last_chunk_impl(size, block_size));
     }
+}
+
+#[test]
+fn sub_chunk_group_query() {
+    let tree = BaoTree::new(ByteNum(1024 * 32), BlockSize(4));
+    let ranges = ChunkRanges::from(ChunkNum(16)..ChunkNum(24));
+    let items = ResponseIter::new(tree, ranges)
+        .filter_map(|x| match x {
+                BaoChunk::Leaf { .. } => Some(x),
+                _ => None,
+            }
+        )
+        .collect::<Vec<_>>();
+    println!("{:?}", items);
 }
 
 proptest! {

--- a/src/tests2.rs
+++ b/src/tests2.rs
@@ -8,7 +8,6 @@
 //! handcrafted or from a previous failure of a proptest.
 use bytes::{Bytes, BytesMut};
 use proptest::prelude::*;
-use proptest::strategy::{Just, Strategy};
 use range_collections::{RangeSet2, RangeSetRef};
 use smallvec::SmallVec;
 use std::ops::Range;


### PR DESCRIPTION
The split into chunks produced more chunks than strictly necessary when going below the chunk group size. This is due to the fact that the left side of the range was not properly canonicalised when going deeper into the tree, so the is_all test to check if further recursion is necessary would return false.

See the test.