### PR TITLE
refactor: Get rid of the prefix and make the outboard traits simpler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,29 +3,6 @@
 version = 3
 
 [[package]]
-name = "abao"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daa0989489b05a455a9707adbbbc17443edf7bbc902ce499cd3b84148d68a40"
-dependencies = [
- "arrayref",
- "arrayvec",
- "blake3",
- "futures",
- "tokio",
-]
-
-[[package]]
-name = "abao"
-version = "0.2.0"
-source = "git+https://github.com/n0-computer/abao?branch=post-order-outboard#9675e0426badc06fe728aea72d02892c91f5caa1"
-dependencies = [
- "arrayref",
- "arrayvec",
- "blake3",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +154,6 @@ dependencies = [
 name = "bao-tree"
 version = "0.11.1"
 dependencies = [
- "abao 0.2.0 (git+https://github.com/n0-computer/abao?branch=post-order-outboard)",
  "anyhow",
  "bao",
  "bytes",
@@ -395,7 +371,6 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "abao 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "bao",
  "bao-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ harness = false
 [workspace]
 members = ["cli"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[example]]
 name = "cli"
 required-features = ["tokio_fsm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ default = ["tokio_fsm", "validate"]
 hex = "0.4.3"
 bao = "0.12.1"
 tokio = { version = "1", features = ["full"] }
-# abao with chunk group size 16 (abao default)
-abao = { git = "https://github.com/n0-computer/abao", branch = "post-order-outboard", features = ["group_size_1k"], default_features = false }
 proptest = "1.0.0"
 rand = "0.8.5"
 criterion = "0.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,6 @@ bao-tree = { path = "../" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1.0.72"
 bao = "0.12.1"
-abao = "0.2.0"
 
 [[bin]]
 name = "bao-tree"

--- a/src/io/fsm.rs
+++ b/src/io/fsm.rs
@@ -699,6 +699,19 @@ async fn outboard_post_order_impl(
     Ok(hash)
 }
 
+/// Copy an outboard to another outboard.
+///
+/// This can be used to persist an in memory outboard or to change from
+/// pre-order to post-order.
+pub async fn copy(mut from: impl Outboard, mut to: impl OutboardMut) -> io::Result<()> {
+    let tree = from.tree();
+    for node in tree.pre_order_nodes_iter() {
+        let hash_pair = from.load(node).await?.unwrap();
+        to.save(node, &hash_pair).await?;
+    }
+    Ok(())
+}
+
 #[cfg(feature = "validate")]
 mod validate {
     use std::{io, ops::Range};
@@ -708,8 +721,8 @@ mod validate {
     use iroh_io::AsyncSliceReader;
 
     use crate::{
-        blake3, hash_subtree, rec::truncate_ranges, split, BaoTree, ChunkNum, ChunkRangesRef,
-        TreeNode,
+        blake3, hash_subtree, rec::truncate_ranges, split, BaoTree, ByteNum, ChunkNum,
+        ChunkRangesRef, TreeNode,
     };
 
     use super::Outboard;
@@ -779,11 +792,10 @@ mod validate {
 
         async fn yield_if_valid(
             &mut self,
-            node: TreeNode,
+            range: Range<ByteNum>,
             hash: &blake3::Hash,
             is_root: bool,
         ) -> io::Result<()> {
-            let range = self.tree.byte_range(node);
             let len = (range.end - range.start).to_usize();
             let data = self.data.read_at(range.start.0, len).await?;
             // is_root is always false because the case of a single chunk group is handled before calling this function
@@ -810,8 +822,9 @@ mod validate {
                     return Ok(());
                 }
                 let node = shifted.subtract_block_size(self.tree.block_size.0);
+                let (l, m, r) = self.tree.leaf_byte_ranges3(node);
                 if !self.tree.is_relevant_for_outboard(node) {
-                    self.yield_if_valid(node, parent_hash, is_root).await?;
+                    self.yield_if_valid(l..r, parent_hash, is_root).await?;
                     return Ok(());
                 }
                 let Some((l_hash, r_hash)) = self.outboard.load(node).await? else {
@@ -823,26 +836,20 @@ mod validate {
                     // hash mismatch, we can't validate
                     return Ok(());
                 };
-                if node.is_leaf() {
-                    self.yield_if_valid(node, parent_hash, is_root).await?;
-                } else {
-                    let (l_ranges, r_ranges) = split(ranges, node);
-                    if shifted.is_leaf() {
-                        if !l_ranges.is_empty() {
-                            let l: TreeNode = node.left_child().unwrap();
-                            self.yield_if_valid(l, &l_hash, false).await?;
-                        }
-                        if !r_ranges.is_empty() {
-                            let r = node.right_descendant(self.tree.filled_size()).unwrap();
-                            self.yield_if_valid(r, &r_hash, false).await?;
-                        }
-                    } else {
-                        // recurse (we are in the domain of the shifted tree)
-                        let left = shifted.left_child().unwrap();
-                        self.validate_rec(&l_hash, left, false, l_ranges).await?;
-                        let right = shifted.right_descendant(self.shifted_filled_size).unwrap();
-                        self.validate_rec(&r_hash, right, false, r_ranges).await?;
+                let (l_ranges, r_ranges) = split(ranges, node);
+                if shifted.is_leaf() {
+                    if !l_ranges.is_empty() {
+                        self.yield_if_valid(l..m, &l_hash, false).await?;
                     }
+                    if !r_ranges.is_empty() {
+                        self.yield_if_valid(m..r, &r_hash, false).await?;
+                    }
+                } else {
+                    // recurse (we are in the domain of the shifted tree)
+                    let left = shifted.left_child().unwrap();
+                    self.validate_rec(&l_hash, left, false, l_ranges).await?;
+                    let right = shifted.right_descendant(self.shifted_filled_size).unwrap();
+                    self.validate_rec(&r_hash, right, false, r_ranges).await?;
                 }
                 Ok(())
             }
@@ -908,8 +915,7 @@ mod validate {
             ranges: &'b ChunkRangesRef,
         ) -> LocalBoxFuture<'b, io::Result<()>> {
             async move {
-                let yield_node_range = |node| {
-                    let range = self.tree.byte_range(node);
+                let yield_node_range = |range: Range<ByteNum>| {
                     self.co
                         .yield_(Ok(range.start.full_chunks()..range.end.chunks()))
                 };
@@ -918,8 +924,9 @@ mod validate {
                     return Ok(());
                 }
                 let node = shifted.subtract_block_size(self.tree.block_size.0);
+                let (l, m, r) = self.tree.leaf_byte_ranges3(node);
                 if !self.tree.is_relevant_for_outboard(node) {
-                    yield_node_range(node).await;
+                    yield_node_range(l..r).await;
                     return Ok(());
                 }
                 let Some((l_hash, r_hash)) = self.outboard.load(node).await? else {
@@ -931,26 +938,20 @@ mod validate {
                     // hash mismatch, we can't validate
                     return Ok(());
                 };
-                if node.is_leaf() {
-                    yield_node_range(node).await;
-                } else {
-                    let (l_ranges, r_ranges) = split(ranges, node);
-                    if shifted.is_leaf() {
-                        if !l_ranges.is_empty() {
-                            let l = node.left_child().unwrap();
-                            yield_node_range(l).await;
-                        }
-                        if !r_ranges.is_empty() {
-                            let r = node.right_descendant(self.tree.filled_size()).unwrap();
-                            yield_node_range(r).await;
-                        }
-                    } else {
-                        // recurse (we are in the domain of the shifted tree)
-                        let left = shifted.left_child().unwrap();
-                        self.validate_rec(&l_hash, left, false, l_ranges).await?;
-                        let right = shifted.right_descendant(self.shifted_filled_size).unwrap();
-                        self.validate_rec(&r_hash, right, false, r_ranges).await?;
+                let (l_ranges, r_ranges) = split(ranges, node);
+                if shifted.is_leaf() {
+                    if !l_ranges.is_empty() {
+                        yield_node_range(l..m).await;
                     }
+                    if !r_ranges.is_empty() {
+                        yield_node_range(m..r).await;
+                    }
+                } else {
+                    // recurse (we are in the domain of the shifted tree)
+                    let left = shifted.left_child().unwrap();
+                    self.validate_rec(&l_hash, left, false, l_ranges).await?;
+                    let right = shifted.right_descendant(self.shifted_filled_size).unwrap();
+                    self.validate_rec(&r_hash, right, false, r_ranges).await?;
                 }
                 Ok(())
             }

--- a/src/io/fsm.rs
+++ b/src/io/fsm.rs
@@ -142,7 +142,7 @@ impl<R: AsyncSliceReader> Outboard for PreOrderOutboard<R> {
         let Some(offset) = self.tree.pre_order_offset(node) else {
             return Ok(None);
         };
-        let offset = offset * 64 + 8;
+        let offset = offset * 64;
         let content = self.data.read_at(offset, 64).await?;
         Ok(Some(if content.len() != 64 {
             (blake3::Hash::from([0; 32]), blake3::Hash::from([0; 32]))
@@ -175,7 +175,7 @@ impl<W: AsyncSliceWriter> OutboardMut for PreOrderOutboard<W> {
         let Some(offset) = self.tree.pre_order_offset(node) else {
             return Ok(());
         };
-        let offset = offset * 64 + 8;
+        let offset = offset * 64;
         let mut buf = [0u8; 64];
         buf[..32].copy_from_slice(hash_pair.0.as_bytes());
         buf[32..].copy_from_slice(hash_pair.1.as_bytes());

--- a/src/io/fsm.rs
+++ b/src/io/fsm.rs
@@ -706,8 +706,9 @@ async fn outboard_post_order_impl(
 pub async fn copy(mut from: impl Outboard, mut to: impl OutboardMut) -> io::Result<()> {
     let tree = from.tree();
     for node in tree.pre_order_nodes_iter() {
-        let hash_pair = from.load(node).await?.unwrap();
-        to.save(node, &hash_pair).await?;
+        if let Some(hash_pair) = from.load(node).await? {
+            to.save(node, &hash_pair).await?;
+        }
     }
     Ok(())
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -74,7 +74,7 @@ pub fn outboard_size(size: u64, block_size: BlockSize) -> u64 {
 /// Computes the pre order outboard of a file in memory.
 pub fn outboard(input: impl AsRef<[u8]>, block_size: BlockSize) -> (Vec<u8>, blake3::Hash) {
     let outboard = PostOrderMemOutboard::create(input, block_size).flip();
-    let hash = *outboard.hash();
+    let hash = outboard.root;
     (outboard.into_inner_with_prefix(), hash)
 }
 
@@ -100,8 +100,7 @@ pub fn round_up_to_chunks(ranges: &RangeSetRef<u64>) -> ChunkRanges {
     res
 }
 
-/// Given a range set of byte ranges, round it up to chunk groups
-/// Given a range set of chunk ranges, return the full chunk groups.
+/// Given a range set of byte ranges, round it up to chunk groups.
 ///
 /// If we store outboard data at a level of granularity of `block_size`, we can only
 /// share full chunk groups because we don't have proofs for anything below a chunk group.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -40,22 +40,35 @@ pub struct Leaf {
     pub data: Bytes,
 }
 
+/// A content item for the bao streaming protocol.
+///
+/// After reading the initial header, the only possible items are `Parent` and
+/// `Leaf`.
+#[derive(Debug)]
+pub enum BaoContentItem {
+    /// a parent node, to update the outboard
+    Parent(Parent),
+    /// a leaf node, to write to the file
+    Leaf(Leaf),
+}
+
+impl From<Parent> for BaoContentItem {
+    fn from(p: Parent) -> Self {
+        Self::Parent(p)
+    }
+}
+
+impl From<Leaf> for BaoContentItem {
+    fn from(l: Leaf) -> Self {
+        Self::Leaf(l)
+    }
+}
+
 /// The outboard size of a file of size `size` with a block size of `block_size`
+///
+/// This is the outboard size *without* the size prefix.
 pub fn outboard_size(size: u64, block_size: BlockSize) -> u64 {
     BaoTree::new(ByteNum(size), block_size).outboard_size().0
-}
-
-/// The outboard size including the 8 byte size header
-///
-/// This exists mostly as a homage to the original bao implementation.
-pub fn outboard_size_with_prefix(size: u64, block_size: BlockSize) -> u64 {
-    outboard_size(size, block_size) + 8
-}
-
-/// The encoded size of a file of size `size` with a block size of `block_size`,
-/// including a size prefix.
-pub fn encoded_size(size: u64, block_size: BlockSize) -> u64 {
-    outboard_size_with_prefix(size, block_size) + size
 }
 
 /// Computes the pre order outboard of a file in memory.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -41,18 +41,21 @@ pub struct Leaf {
 }
 
 /// The outboard size of a file of size `size` with a block size of `block_size`
-pub fn raw_outboard_size(size: u64, block_size: BlockSize) -> u64 {
-    BaoTree::raw_outboard_size(ByteNum(size), block_size).0
+pub fn outboard_size(size: u64, block_size: BlockSize) -> u64 {
+    BaoTree::new(ByteNum(size), block_size).outboard_size().0
 }
 
 /// The outboard size including the 8 byte size header
-pub fn outboard_size(size: u64, block_size: BlockSize) -> u64 {
-    BaoTree::outboard_size(ByteNum(size), block_size).0
+///
+/// This exists mostly as a homage to the original bao implementation.
+pub fn outboard_size_with_prefix(size: u64, block_size: BlockSize) -> u64 {
+    outboard_size(size, block_size) + 8
 }
 
-/// The encoded size of a file of size `size` with a block size of `block_size`
+/// The encoded size of a file of size `size` with a block size of `block_size`,
+/// including a size prefix.
 pub fn encoded_size(size: u64, block_size: BlockSize) -> u64 {
-    outboard_size(size, block_size) + size
+    outboard_size_with_prefix(size, block_size) + size
 }
 
 /// Computes the pre order outboard of a file in memory.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -41,6 +41,11 @@ pub struct Leaf {
 }
 
 /// The outboard size of a file of size `size` with a block size of `block_size`
+pub fn raw_outboard_size(size: u64, block_size: BlockSize) -> u64 {
+    BaoTree::raw_outboard_size(ByteNum(size), block_size).0
+}
+
+/// The outboard size including the 8 byte size header
 pub fn outboard_size(size: u64, block_size: BlockSize) -> u64 {
     BaoTree::outboard_size(ByteNum(size), block_size).0
 }

--- a/src/io/outboard.rs
+++ b/src/io/outboard.rs
@@ -95,6 +95,9 @@ impl crate::io::fsm::OutboardMut for EmptyOutboard {
 }
 
 /// A generic outboard in pre order
+///
+/// Caution: unlike the outboard implementation in the bao crate, this
+/// implementation does not assume an 8 byte size prefix.
 #[derive(Debug, Clone)]
 pub struct PreOrderOutboard<R> {
     /// root hash
@@ -116,11 +119,11 @@ impl<R> PreOrderOutboard<R> {
 #[derive(Debug, Clone)]
 pub struct PostOrderOutboard<R> {
     /// root hash
-    pub(crate) root: blake3::Hash,
+    pub root: blake3::Hash,
     /// tree defining the data
-    pub(crate) tree: BaoTree,
+    pub tree: BaoTree,
     /// hashes with length prefix
-    pub(crate) data: R,
+    pub data: R,
 }
 
 impl<R> PostOrderOutboard<R> {

--- a/src/io/outboard.rs
+++ b/src/io/outboard.rs
@@ -132,6 +132,9 @@ impl<R> PostOrderOutboard<R> {
 }
 
 /// A post order outboard that is optimized for memory storage.
+///
+/// The traits are implemented for fixed size slices or mutable slices, so you
+/// must make sure that the data is already the right size.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PostOrderMemOutboard<T = Vec<u8>> {
     /// root hash
@@ -172,8 +175,9 @@ impl PostOrderMemOutboard {
 impl<T: AsRef<[u8]>> PostOrderMemOutboard<T> {
     /// Create a new outboard from a root hash, tree, and existing outboard data.
     ///
-    /// This will just do a check that the data is the right size, but not check
-    /// the actual hashes.
+    /// Note that when writing to a [PreOrderMemOutboard], you must make sure
+    /// that the data is already the right size. The size can be computed with
+    /// [BaoTree::outboard_size].
     pub fn new(root: blake3::Hash, tree: BaoTree, outboard_data: T) -> Self {
         Self {
             root,
@@ -310,6 +314,9 @@ fn flip_post(root: blake3::Hash, tree: BaoTree, data: &[u8]) -> PreOrderMemOutbo
 }
 
 /// A pre order outboard that is optimized for memory storage.
+///
+/// The traits are implemented for fixed size slices or mutable slices, so you
+/// must make sure that the data is already the right size.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreOrderMemOutboard<T = Vec<u8>> {
     /// root hash
@@ -348,8 +355,9 @@ impl PreOrderMemOutboard {
 impl<T: AsRef<[u8]>> PreOrderMemOutboard<T> {
     /// Create a new outboard from a root hash, tree, and existing outboard data.
     ///
-    /// This will just do a check that the data is the right size, but not check
-    /// the actual hashes.
+    /// Note that when writing to a [PreOrderMemOutboard], you must make sure
+    /// that the data is already the right size. The size can be computed with
+    /// [BaoTree::outboard_size].
     ///
     /// Note that if you have data with a length prefix, you have to remove the prefix first.
     pub fn new(root: blake3::Hash, tree: BaoTree, outboard_data: T) -> Self {

--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -554,8 +554,9 @@ fn read_parent(mut from: impl Read) -> std::io::Result<(blake3::Hash, blake3::Ha
 pub fn copy(from: impl Outboard, mut to: impl OutboardMut) -> io::Result<()> {
     let tree = from.tree();
     for node in tree.pre_order_nodes_iter() {
-        let hash_pair = from.load(node)?.unwrap();
-        to.save(node, &hash_pair)?;
+        if let Some(hash_pair) = from.load(node)? {
+            to.save(node, &hash_pair)?;
+        }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ impl BaoTree {
         ByteNum(self.outboard_hash_pairs() * 64)
     }
 
+    #[allow(dead_code)]
     fn filled_size(&self) -> TreeNode {
         let blocks = self.chunks();
         let n = (blocks.0 + 1) / 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub type ChunkRanges = range_collections::RangeSet2<ChunkNum>;
 
 /// A referenceable set of chunk ranges
 ///
-/// [ChunkRanges] implements [AsRef<ChunkRangesRef>].
+/// [ChunkRanges] implements [`AsRef<ChunkRangesRef>`].
 pub type ChunkRangesRef = range_collections::RangeSetRef<ChunkNum>;
 
 fn hash_subtree(start_chunk: u64, data: &[u8], is_root: bool) -> blake3::Hash {
@@ -204,7 +204,7 @@ impl BaoTree {
     /// Traverse the part of the tree that is relevant for a ranges querys
     /// in pre order as [NodeInfo]s
     ///
-    /// This is mostly used internally by the [PreOrderChunkIterRef]
+    /// This is mostly used internally.
     ///
     /// When `min_level` is set to a value greater than 0, the iterator will
     /// skip all branch nodes that are at a level < min_level if they are fully

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,13 +249,8 @@ impl BaoTree {
         self.blocks().0 - 1
     }
 
-    pub(crate) fn outboard_size(size: ByteNum, block_size: BlockSize) -> ByteNum {
-        Self::raw_outboard_size(size, block_size) + 8
-    }
-
-    pub(crate) fn raw_outboard_size(size: ByteNum, block_size: BlockSize) -> ByteNum {
-        let tree = Self::new(size, block_size);
-        ByteNum(tree.outboard_hash_pairs() * 64)
+    pub(crate) fn outboard_size(&self) -> ByteNum {
+        ByteNum(self.outboard_hash_pairs() * 64)
     }
 
     fn filled_size(&self) -> TreeNode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,12 @@
 //! [TreeNode] provides various helpers to e.g. get the offset of a node in
 //! different traversal orders.
 //!
-//! There are various newtypes for the different kinds of integers used in the
-//! tree, e.g. [ByteNum] for number of bytes, [ChunkNum] for number of chunks.
+//! There are newtypes for the different kinds of integers used in the
+//! tree:
+//! [ByteNum] is an u64 number of bytes,
+//! [ChunkNum] is an u64 number of chunks,
+//! [TreeNode] is an u64 tree node identifier,
+//! and [BlockSize] is the log base 2 of the chunk group size.
 //!
 //! All this is then used in the [io] module to implement the actual io, both
 //! synchronous and asynchronous.
@@ -249,7 +253,10 @@ impl BaoTree {
         self.blocks().0 - 1
     }
 
-    pub(crate) fn outboard_size(&self) -> ByteNum {
+    /// The outboard size for this tree.
+    ///
+    /// This is the outboard size *without* the size prefix.
+    pub fn outboard_size(&self) -> ByteNum {
         ByteNum(self.outboard_hash_pairs() * 64)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,8 +250,12 @@ impl BaoTree {
     }
 
     pub(crate) fn outboard_size(size: ByteNum, block_size: BlockSize) -> ByteNum {
+        Self::raw_outboard_size(size, block_size) + 8
+    }
+
+    pub(crate) fn raw_outboard_size(size: ByteNum, block_size: BlockSize) -> ByteNum {
         let tree = Self::new(size, block_size);
-        ByteNum(tree.outboard_hash_pairs() * 64 + 8)
+        ByteNum(tree.outboard_hash_pairs() * 64)
     }
 
     fn filled_size(&self) -> TreeNode {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,6 @@ fn post_order_outboard_reference_2(data: &[u8]) -> PostOrderMemOutboard {
         BaoTree::new(ByteNum(data.len() as u64), BlockSize::ZERO),
         outboard,
     )
-    .unwrap()
 }
 
 /// Computes a reference pre order outboard using the bao crate (chunk_group_log = 0) and then flips it to a post-order outboard.
@@ -77,7 +76,7 @@ fn post_order_outboard_reference(data: &[u8]) -> PostOrderMemOutboard {
     let tree = BaoTree::new(ByteNum(data.len() as u64), BlockSize::ZERO);
     outboard.splice(..8, []);
     let pre = PreOrderMemOutboard::new(hash, tree, outboard);
-    pre.unwrap().flip()
+    pre.flip()
 }
 
 fn encode_slice_reference(data: &[u8], chunk_range: Range<ChunkNum>) -> (Vec<u8>, blake3::Hash) {
@@ -103,8 +102,6 @@ fn bao_tree_encode_slice_comparison_impl(data: Vec<u8>, mut range: Range<ChunkNu
     };
     let expected = encode_slice_reference(&data, range.clone()).0;
     let ob = PostOrderMemOutboard::create(&data, BlockSize::ZERO);
-    let hash = ob.root();
-    let outboard = ob.into_inner_with_suffix();
     let ranges = ChunkRanges::from(range);
     let actual = encode_ranges_reference(&data, &ranges, BlockSize::ZERO).0;
     assert_eq!(expected.len(), actual.len());
@@ -120,7 +117,6 @@ fn bao_tree_encode_slice_comparison_impl(data: Vec<u8>, mut range: Range<ChunkNu
         return;
     }
     let mut actual2 = Vec::new();
-    let ob = PostOrderMemOutboard::load(hash, outboard, BlockSize::ZERO).unwrap();
     encode_ranges(&data, &ob, &ranges, Cursor::new(&mut actual2)).unwrap();
     assert_eq!(expected.len(), actual2.len());
     assert_eq!(expected, actual2);
@@ -230,7 +226,7 @@ fn bao_tree_outboard_levels() {
         assert_eq!(expected, hash);
         assert_eq!(
             ByteNum(outboard.len() as u64),
-            BaoTree::outboard_size(ByteNum(td.len() as u64), block_size)
+            BaoTree::new(ByteNum(td.len() as u64), block_size).outboard_size() + 8
         );
     }
 }


### PR DESCRIPTION
this removes the assumption that pre order outboards have a size prefix of 8 bytes. So all the offset calculations lose the `+8`. I found it useful to store the size somewhere else, and if you want the prefix you can always add it manually.

This also adds methods to compute outboards.