### PR TITLE
fix: fix hazmat assertion error when using fsm io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-io"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1047ad5ca29ab4ff316b6830d86e7ea52cea54325e4d4a849692e1274b498"
+checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
 dependencies = [
  "bytes",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1"
 bytes = { version = "1" }
 futures-lite = { version = "2.3", optional = true }
 self_cell = { version = "1" }
-iroh-io = { version = "0.6.0", default-features = false, optional = true }
+iroh-io = { version = "0.6.2", default-features = false, optional = true }
 positioned-io = { version = "0.3.1", default-features = false }
 genawaiter = { version = "0.99.1", features = ["futures03"], optional = true }
 tokio = { version = "1", features = ["sync"], default-features = false, optional = true }
@@ -42,7 +42,7 @@ proptest = "1.0.0"
 rand = "0.8.5"
 criterion = "0.4.0"
 tempfile = "3.6.0"
-iroh-io = { version = "0.6.0" }
+iroh-io = { version = "0.6.2" }
 warp = "0.3.5"
 proc-macro2 = "1.0.66"
 test-strategy = "0.3.1"


### PR DESCRIPTION
The new hazmat API is more strict than the previous guts api when it comes to incorrect use of the Hasher.

This exposed a bug that previously led to the exact expected behaviour. When the remote stops sending data, e.g. because of the data being invalid, you could get a read of size 0. Feeding this blob into the hasher with is_root set to false would before just produce a wrong hash - correctly causing the data to be rejected.

Now it triggers an assertion, because hashing an empty blob with is_root set to false can never be correct.

With this change we make sure to bail out immediately with an io error when there is a short read, instead of feeding the data to the hasher.