### PR TITLE
Release v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bao-tree"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 description = "BLAKE3 verfiied streaming with custom chunk groups and range set queries"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
v0.15.2 was not a semver compatible release since it introduced a feature flag and hid existing public API behind it, so crates depending on bao-tree with default-features=false would break.