### PR TITLE
Add Hash trait to TreeNode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,7 +547,7 @@ pub(crate) const fn blocks(size: u64, block_size: BlockSize) -> u64 {
 /// You typically don't have to use this, but it can be useful for debugging
 /// and error handling. Hash validation errors contain a `TreeNode` that allows
 /// you to find the position where validation failed.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TreeNode(u64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,7 +549,7 @@ pub(crate) const fn blocks(size: u64, block_size: BlockSize) -> u64 {
 /// you to find the position where validation failed.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TreeNode(u64);
+pub struct TreeNode(pub u64);
 
 impl fmt::Display for TreeNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -129,7 +129,7 @@ pub(crate) const BLAKE3_CHUNK_SIZE: usize = 1024;
 /// The actual size in bytes can be computed with [BlockSize::bytes].
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BlockSize(pub(crate) u8);
+pub struct BlockSize(pub u8);
 
 impl fmt::Display for BlockSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
I'm trying to use TreeNodes in a HashMap (so that I can easily traverse the tree) and noticed that the Hash trait isn't implemented for them. 